### PR TITLE
Increase to 6 pools

### DIFF
--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -50,7 +50,9 @@ module "eks" {
       override_instance_type_2 = "c5.large"
       override_instance_type_3 = "t3.large"
       override_instance_type_4 = "r5.large"
-      spot_instance_pools      = 4
+      override_instance_type_5 = "t3.nano"
+      override_instance_type_6 = "t3.micro"
+      spot_instance_pools      = 6
       asg_max_size             = 5
       asg_desired_capacity     = 5
       kubelet_extra_args       = "--node-labels=kubernetes.io/lifecycle=spot"

--- a/local.tf
+++ b/local.tf
@@ -59,6 +59,8 @@ locals {
     override_instance_type_2                 = ""     # Override instance type 2 for mixed instances policy
     override_instance_type_3                 = ""     # Override instance type 3 for mixed instances policy
     override_instance_type_4                 = ""     # Override instance type 4 for mixed instances policy
+    override_instance_type_5                 = ""     # Override instance type 4 for mixed instances policy
+    override_instance_type_6                 = ""     # Override instance type 4 for mixed instances policy
     on_demand_allocation_strategy            = "prioritized"  # Strategy to use when launching on-demand instances. Valid values: prioritized.
     on_demand_base_capacity                  = "0"            # Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances
     on_demand_percentage_above_base_capacity = "0"            # Percentage split between on-demand and Spot instances above the base on-demand capacity

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -46,6 +46,13 @@ resource "aws_autoscaling_group" "workers_launch_template_mixed" {
       override {
         instance_type = "${lookup(var.worker_groups_launch_template_mixed[count.index], "override_instance_type_4", local.workers_group_defaults["override_instance_type_4"])}"
       }
+      override {
+        instance_type = "${lookup(var.worker_groups_launch_template_mixed[count.index], "override_instance_type_5", local.workers_group_defaults["override_instance_type_4"])}"
+      }
+
+      override {
+        instance_type = "${lookup(var.worker_groups_launch_template_mixed[count.index], "override_instance_type_6", local.workers_group_defaults["override_instance_type_4"])}"
+      }
     }
   }
 


### PR DESCRIPTION
Increasing the available overrides to 6 compared to 4, and adding the spot_allocation_strategy.